### PR TITLE
Enable output redirection

### DIFF
--- a/gifify.sh
+++ b/gifify.sh
@@ -8,7 +8,6 @@ Usage:
 Options: (all optional)
   c CROP:   The x and y crops, from the top left of the image, i.e. 640:480
   o OUTPUT: The output file
-  n:        Do not upload the resulting image to CloudApp
   r FPS:    Output at this (frame)rate (default 10)
   s SPEED:  Output using this speed modifier (default 1)
             NOTE: GIFs max out at 100fps depending on platform. For consistency,
@@ -16,7 +15,6 @@ Options: (all optional)
   p SCALE:  Rescale the output, e.g. 320:240
   F         Fast mode produces results faster, at lower quality
   C         Conserve memory by writing frames to disk (slower)
-  x:        Remove the original file and resulting .gif once the script is complete
 
 Example:
   gifify -c 240:80 -o my-gif -x my-movie.mov
@@ -32,18 +30,16 @@ useio=0
 
 OPTERR=0
 
-while getopts "c:o:p:r:s:nxFCh" opt; do
+while getopts "c:o:p:r:s:FCh" opt; do
   case $opt in
     c) crop=$OPTARG;;
     h) printHelpAndExit 0;;
     o) output=$OPTARG;;
-    n) noupload=1;;
     p) scale=$OPTARG;;
     r) fps=$OPTARG;;
     s) speed=$OPTARG;;
     F) fast=1;;
     C) useio=1;;
-    x) cleanup=1;;
     *) printHelpAndExit 1;;
   esac
 done
@@ -98,15 +94,4 @@ else
   ffmpeg -loglevel panic -i "$filename" $filter -r $fps -f image2pipe -vcodec ppm - >> "$temp"
   cat "$temp" | convert +dither -layers Optimize -delay $delay - gif:- | gifsicle --optimize=3 - > "$output"
   rm "$temp"
-fi
-
-if [ $noupload -ne 1 ]; then
-  open -a CloudApp "$output"
-
-  if [ $cleanup ]; then
-    rm "$filename"
-    rm "$output"
-  fi
-else
-  echo "$output"
 fi

--- a/gifify.sh
+++ b/gifify.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function printHelpAndExit {
   echo 'Usage:'

--- a/gifify.sh
+++ b/gifify.sh
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
 
 function printHelpAndExit {
-  echo 'Usage:'
-  echo '  gifify [options] filename'
-  echo ''
-  echo 'Options: (all optional)'
-  echo '  c CROP:   The x and y crops, from the top left of the image, i.e. 640:480'
-  echo '  o OUTPUT: The basename of the file to be output (default "output")'
-  echo '  n:        Do not upload the resulting image to CloudApp'
-  echo '  r FPS:    Output at this (frame)rate (default 10)'
-  echo '  s SPEED:  Output using this speed modifier (default 1)'
-  echo '            NOTE: GIFs max out at 100fps depending on platform. For consistency,'
-  echo '            ensure that FPSxSPEED is not > ~60!'
-  echo '  p SCALE:  Rescale the output, e.g. 320:240'
-  echo '  x:        Remove the original file and resulting .gif once the script is complete'
-  echo ''
-  echo 'Example:'
-  echo '  gifify -c 240:80 -o my-gif -x my-movie.mov'
-  exit $1
+cat <<EOF
+Usage:
+  gifify [options] filename
+
+Options: (all optional)
+  c CROP:   The x and y crops, from the top left of the image, i.e. 640:480
+  o OUTPUT: The basename of the file to be output (default "output")
+  n:        Do not upload the resulting image to CloudApp
+  r FPS:    Output at this (frame)rate (default 10)
+  s SPEED:  Output using this speed modifier (default 1)
+            NOTE: GIFs max out at 100fps depending on platform. For consistency,
+            ensure that FPSxSPEED is not > ~60!
+  p SCALE:  Rescale the output, e.g. 320:240
+  x:        Remove the original file and resulting .gif once the script is complete
+
+Example:
+  gifify -c 240:80 -o my-gif -x my-movie.mov
+EOF
+exit $1
 }
 
 noupload=0

--- a/gifify.sh
+++ b/gifify.sh
@@ -3,18 +3,18 @@
 function printHelpAndExit {
 cat <<EOF
 Usage:
-  gifify [options] filename
+  gifify [options] input-file output-file
 
 Options: (all optional)
-  c CROP:   The x and y crops, from the top left of the image, i.e. 640:480
-  o OUTPUT: The output file
-  r FPS:    Output at this (frame)rate (default 10)
-  s SPEED:  Output using this speed modifier (default 1)
+  -c value  Crop the input from the top left of the image, i.e. 640:480
+  -C        Conserve memory by writing frames to disk (slower)
+  -F        Fast mode produces results faster, at lower quality
+  -o value  The output file
+  -r value  Set the output framerate (default 10)
+  -s value  Set the speed modifier (default 1)
             NOTE: GIFs max out at 100fps depending on platform. For consistency,
             ensure that FPSxSPEED is not > ~60!
-  p SCALE:  Rescale the output, e.g. 320:240
-  F         Fast mode produces results faster, at lower quality
-  C         Conserve memory by writing frames to disk (slower)
+  -p value  Scale the output, e.g. 320:240
 
 Example:
   gifify -c 240:80 -o my-gif -x my-movie.mov
@@ -33,26 +33,29 @@ OPTERR=0
 while getopts "c:o:p:r:s:FCh" opt; do
   case $opt in
     c) crop=$OPTARG;;
+    C) useio=1;;
+    F) fast=1;;
     h) printHelpAndExit 0;;
-    o) output=$OPTARG;;
+    o) outfile=$OPTARG;;
     p) scale=$OPTARG;;
     r) fps=$OPTARG;;
     s) speed=$OPTARG;;
-    F) fast=1;;
-    C) useio=1;;
     *) printHelpAndExit 1;;
   esac
 done
 
 shift $(( OPTIND - 1 ))
 
-filename="$1"
-
-if [ -z "$output" ]; then
-  output="${filename}.gif"
+infile="$1"
+if [ -z "$outfile" ]; then
+  outfile="$2"
 fi
 
-if [ -z "$filename" ]; then printHelpAndExit 1; fi
+if [ -z "$outfile" ]; then
+  outfile="${infile}.gif"
+fi
+
+if [ -z "$infile" ]; then printHelpAndExit 1; fi
 
 if [ $crop ]; then
   crop="crop=${crop}:0:0"
@@ -83,15 +86,15 @@ delay=$(bc -l <<< "100/$fps/$speed")
 
 if [ $useio -ne 1 ]; then
   if [ $fast -ne 1 ]; then
-    ffmpeg -loglevel panic -i "$filename" $filter -r $fps -f image2pipe -vcodec ppm - | convert +dither -layers Optimize -delay $delay - gif:- | gifsicle --optimize=3 - > "$output"
+    ffmpeg -loglevel panic -i "$infile" $filter -r $fps -f image2pipe -vcodec ppm - | convert +dither -layers Optimize -delay $delay - gif:- | gifsicle --optimize=3 - -o "$outfile"
   else
     # gifsicle accepts only int values for delay
     delay=$(( 100 / $fps / $speed ))
-    ffmpeg -loglevel panic -i "$filename" $filter -r $fps -pix_fmt rgb24 -f gif - | gifsicle --optimize=3 --delay=${delay} - > "$output"
+    ffmpeg -loglevel panic -i "$infile" $filter -r $fps -pix_fmt rgb24 -f gif - | gifsicle --optimize=3 --delay=${delay} - -o "$outfile"
   fi
 else
   temp=$(mktemp /tmp/tempfile.XXXXXXXXX)
-  ffmpeg -loglevel panic -i "$filename" $filter -r $fps -f image2pipe -vcodec ppm - >> "$temp"
-  cat "$temp" | convert +dither -layers Optimize -delay $delay - gif:- | gifsicle --optimize=3 - > "$output"
+  ffmpeg -loglevel panic -i "$infile" $filter -r $fps -f image2pipe -vcodec ppm - >> "$temp"
+  cat "$temp" | convert +dither -layers Optimize -delay $delay - gif:- | gifsicle --optimize=3 - -o "$outfile"
   rm "$temp"
 fi


### PR DESCRIPTION
Many UNIX tools support the ability to pipe output to other programs for processing. Adding support for this functionality is relatively trivial, given the tools the script utilizes.

If you wish to eliminate the `gifsicle` dependency, using `gif:${outfile}` should work just as well.

This addresses one of the issues mentioned in #14, however I've preserved the `-o` functionality, just because.