### PR TITLE
gifify.sh: require exactly one argument and inform the user

### DIFF
--- a/gifify.sh
+++ b/gifify.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -euo pipefail
-
 function printHelpAndExit {
   echo 'Usage:'
   echo '  gifify [options] filename'
@@ -21,6 +19,14 @@ function printHelpAndExit {
   echo '  gifify -c 240:80 -o my-gif my-movie.mov'
   exit $1
 }
+
+if [ -z "$1" ] || [ -n "$2" ]; then
+  echo 'You need to give exactly one argument'
+  echo ''
+  printHelpAndExit 1
+fi
+
+set -euo pipefail
 
 crop=
 output=


### PR DESCRIPTION
Settings like `set -euo pipefail` are nice in theory, but in practice they prevent from being helpful to the user, hence why it had to be moved down for this to work.

Without this change:

``` bash
$ gifify
/usr/local/bin/gifify: line 24: $1: unbound variable
```

With this change:

``` bash
$ gifify
You need to give exactly one argument

Usage:
  gifify [options] filename

(…) # rest of the help
```

Without this change, giving two arguments also fails silently (it does just one of them, and the user is none the wiser). With it, the script does not proceed.
