### PR TITLE
Fix bug when called with no args in … some env 🐭

### DIFF
--- a/gifify.sh
+++ b/gifify.sh
@@ -44,7 +44,7 @@ done
 
 shift $(( OPTIND - 1 ))
 
-filename=$1
+filename=${1:-}
 
 if [ -z ${output} ]; then
   output=$filename


### PR DESCRIPTION
```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)
Copyright (C) 2007 Free Software Foundation, Inc.
$
$
$ brew info gifify
gifify: stable 4.0, HEAD
Turn movies into GIFs
https://github.com/jclem/gifify
/usr/local/Cellar/gifify/4.0 (6 files, 10.6KB) *
  Built from source on 2020-12-02 at 11:20:22
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gifify.rb
License: MIT
==> Dependencies
Required: ffmpeg ✔, imagemagick ✔
==> Options
--HEAD  
        Install HEAD version
==> Analytics
install: 103 (30 days), 227 (90 days), 910 (365 days)
install-on-request: 102 (30 days), 226 (90 days), 904 (365 days)
build-error: 0 (30 days)
$
$
$ gifify
/usr/local/bin/gifify: line 47: $1: unbound variable
$
```